### PR TITLE
StartTask / Timer

### DIFF
--- a/src/react/Pages/StartTask.jsx
+++ b/src/react/Pages/StartTask.jsx
@@ -82,6 +82,7 @@ const StartTask = () => {
   const [studyTechnique, setStudyTechnique] = useState('pomodoro')
   const [learningInterval, setLearningInterval] = useState(25)
   const [breakInterval, setBreakInterval] = useState(5)
+  const [flowBreakRatio, setFlowBreakRatio] = useState(5)
   const timerRef = useRef(null)
   const topRef = useRef(null)
   const navigate = useNavigate()
@@ -210,13 +211,35 @@ const StartTask = () => {
                     </Typography>
                   </Stack>}
                 { studyTechnique === 'flowmodoro' &&
+                <Stack sx={{ display: 'flex', alignItems: 'center' }}>
                   <Typography
                     variant="subtitle2"
                     color="textSecondary"
                     sx={{ margin: 1 }}
                   >
-                    Work in longer, flexible blocks to reach a deeper flow. Take breaks when it feels natural.
-                  </Typography>}
+                    Work in more flexible intervals to reach a deeper flow. Take breaks when it feels natural.
+                  </Typography>
+                  <Typography sx={{ margin: 1 }}>
+                    Gain
+                    {' '}
+                    <strong>1</strong>
+                    {' '}
+                    minute of break time for every
+                  </Typography>
+                  <Stack sx={{ display: 'flex', flexDirection: 'row' }}>
+                    <TextField
+                      defaultValue={5}
+                      onChange={(e) => setFlowBreakRatio(e.target.value)}
+                      disabled={timerStarted}
+                      slotProps={{ input: { endAdornment: <InputAdornment position="end">min</InputAdornment>,
+                        sx: { borderRadius: '2rem' } } }}
+                      sx={{ width: 150 }}
+                    />
+                    <Typography sx={{ margin: 1, marginTop: 2 }}>
+                      of studying.
+                    </Typography>
+                  </Stack>
+                </Stack>}
 
               </CardContent>
             </Card>
@@ -259,6 +282,7 @@ const StartTask = () => {
                 studyDuration={aproxTimeInMin}
                 learningIntervalTime={parseFloat(learningInterval)}
                 breakIntervalTime={parseFloat(breakInterval)}
+                flowBreakRatio={parseFloat(flowBreakRatio)}
                 isPaused={timerPaused}
                 onTaskComplete={handleTaskComplete}
               />}

--- a/src/react/Pages/Timer/FlowTimer.jsx
+++ b/src/react/Pages/Timer/FlowTimer.jsx
@@ -5,14 +5,14 @@ import { Button, Stack } from '@mui/material'
 
 import displayTime from '../../../hooks/displayTime'
 
-const FlowTimer = ({ studyDuration, isPaused, onTaskComplete }) => {
+const FlowTimer = ({ studyDuration, breakRatio, isPaused, onTaskComplete }) => {
   const [time, setTime] = useState(0)
   const [timePassed, setTimePassed] = useState(0)
   const [isBreak, setBreak] = useState(false)
 
   const switchToBreak = () => {
     setBreak(true)
-    setTime(Math.floor(time / 5))
+    setTime(Math.floor(time / breakRatio))
   }
 
   useEffect(() => {
@@ -37,7 +37,7 @@ const FlowTimer = ({ studyDuration, isPaused, onTaskComplete }) => {
             setTime(time + 1)
           }
         }
-        setTimePassed(timePassed + 1)
+        if (!isBreak) { setTimePassed(timePassed + 1) }
       }, 1000)
 
       return () => {
@@ -64,7 +64,7 @@ const FlowTimer = ({ studyDuration, isPaused, onTaskComplete }) => {
         {' / '}
         {displayTime(studyDuration)}
         {' '}
-        total passed
+        total studied
       </Typography>
 
       <Button fullWidth sx={{ borderRadius: '2rem' }} variant="contained" onClick={() => { switchToBreak() }} disabled={time < 60 || isBreak || studyDuration === timePassed}>
@@ -79,6 +79,7 @@ const FlowTimer = ({ studyDuration, isPaused, onTaskComplete }) => {
 FlowTimer.propTypes = {
   studyDuration: PropTypes.number,
   isPaused: PropTypes.bool,
+  breakRatio: PropTypes.number,
   onTaskComplete: PropTypes.func
 }
 

--- a/src/react/Pages/Timer/PomodoroTimer.jsx
+++ b/src/react/Pages/Timer/PomodoroTimer.jsx
@@ -31,7 +31,7 @@ const PomodoroTimer = ({ studyDuration, learningIntervalTime, breakIntervalTime,
     if (!isRunning || isPaused || totalStudyTimeRemaining <= 0) return
 
     const interval = setInterval(() => {
-      if (sessionTime > 0) {
+      if (sessionTime > 1) {
         setSessionTime(prev => prev - 1)
 
         // ONLY decrement study time during focus sessions, not breaks
@@ -48,6 +48,7 @@ const PomodoroTimer = ({ studyDuration, learningIntervalTime, breakIntervalTime,
           // Focus session finished
           const newSessions = sessionsCompleted + 1
           setSessionsCompleted(newSessions)
+          setTotalStudyTimeRemaining(prev => Math.max(0, prev - 1))
 
           // Check if we've completed all study time
           if (newSessions >= totalSessions) {

--- a/src/react/Pages/Timer/Timer.jsx
+++ b/src/react/Pages/Timer/Timer.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import FlowTimer from './FlowTimer'
 import PomodoroTimer from './PomodoroTimer'
 
-const Timer = ({ studyTechnique, studyDuration, learningIntervalTime, breakIntervalTime, isPaused, onTaskComplete }) => {
+const Timer = ({ studyTechnique, studyDuration, learningIntervalTime, breakIntervalTime, flowBreakRatio, isPaused, onTaskComplete }) => {
   // converting minutes to seconds for displayTime funtion
   if (studyTechnique === 'pomodoro') {
     return (
@@ -21,6 +21,7 @@ const Timer = ({ studyTechnique, studyDuration, learningIntervalTime, breakInter
   return (
     <FlowTimer
       studyDuration={studyDuration * 60}
+      breakRatio={flowBreakRatio}
       isPaused={isPaused}
       onTaskComplete={onTaskComplete}
     />
@@ -33,6 +34,7 @@ Timer.propTypes = {
   learningIntervalTime: PropTypes.number,
   breakIntervalTime: PropTypes.number,
   onTaskComplete: PropTypes.func,
+  flowBreakRatio: PropTypes.number,
   isPaused: PropTypes.bool
 }
 


### PR DESCRIPTION
- break ratio input for flowmodoro added
- flowtimer no longer increments total study time during breaks
- pomodoro timer fixed: additional second during switch between learning and break removed 